### PR TITLE
Add mixin class for testing core packages

### DIFF
--- a/openregistry/api/tests/blanks/core_resource.py
+++ b/openregistry/api/tests/blanks/core_resource.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+
+def empty_listing(self):
+    response = self.app.get('/')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data'], [])
+    self.assertNotIn('{\n    "', response.body)
+    self.assertNotIn('callback({', response.body)
+    self.assertEqual(response.json['next_page']['offset'], '')
+    self.assertNotIn('prev_page', response.json)
+
+    response = self.app.get('/?opt_jsonp=callback')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/javascript')
+    self.assertNotIn('{\n    "', response.body)
+    self.assertIn('callback({', response.body)
+
+    response = self.app.get('/?opt_pretty=1')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertIn('{\n    "', response.body)
+    self.assertNotIn('callback({', response.body)
+
+    response = self.app.get('/?opt_jsonp=callback&opt_pretty=1')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/javascript')
+    self.assertIn('{\n    "', response.body)
+    self.assertIn('callback({', response.body)
+
+    response = self.app.get('/?offset=2015-01-01T00:00:00+02:00&descending=1&limit=10')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data'], [])
+    self.assertIn('descending=1', response.json['next_page']['uri'])
+    self.assertIn('limit=10', response.json['next_page']['uri'])
+    self.assertNotIn('descending=1', response.json['prev_page']['uri'])
+    self.assertIn('limit=10', response.json['prev_page']['uri'])
+
+    response = self.app.get('/?feed=changes')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data'], [])
+    self.assertEqual(response.json['next_page']['offset'], '')
+    self.assertNotIn('prev_page', response.json)
+
+    response = self.app.get('/?feed=changes&offset=0', status=404)
+    self.assertEqual(response.status, '404 Not Found')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['status'], 'error')
+    self.assertEqual(response.json['errors'], [
+        {u'description': u'Offset expired/invalid', u'location': u'querystring', u'name': u'offset'}
+    ])
+
+    response = self.app.get('/?feed=changes&descending=1&limit=10')
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data'], [])
+    self.assertIn('descending=1', response.json['next_page']['uri'])
+    self.assertIn('limit=10', response.json['next_page']['uri'])
+    self.assertNotIn('descending=1', response.json['prev_page']['uri'])
+    self.assertIn('limit=10', response.json['prev_page']['uri'])

--- a/openregistry/api/tests/blanks/mixins.py
+++ b/openregistry/api/tests/blanks/mixins.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from openregistry.api.tests.base import snitch
+
+from .core_resource import empty_listing
+
+
+class CoreResourceTestMixin(object):
+    """ Mixin that contains tests for core packages
+    """
+
+    test_empty_listing = snitch(empty_listing)


### PR DESCRIPTION
Add new directory `blanks`, which will contain common test blanks for assets and lots. Module `blanks.mixins` will have classes with unified tests for resource web testing. 